### PR TITLE
x-sdk-patch-level

### DIFF
--- a/src/services/swagger.ts
+++ b/src/services/swagger.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import ui from './ui'
 import { CodexRenderer } from '../contract/codex-renderer'
 
-export const sdkVersionSuffixPattern = /-SDK\.(\d+)/
+export const sdkPatchLevelAttr = 'x-sdk-patch-level'
 
 /**
  * get patch level from a swagger spec
@@ -12,28 +12,26 @@ export const sdkVersionSuffixPattern = /-SDK\.(\d+)/
  */
 export function getVersionPatchLevel(swagger: Record<string, any>): number {
 
-  if (swagger.info === undefined || swagger.info.version === undefined) {
-    throw new Error('invalid baseline swagger file; version information not found')
+  if (swagger.info === undefined || typeof swagger.info !== 'object') {
+    throw new Error('invalid baseline swagger file; info section not found')
   }
 
-  const match = swagger.info.version.match(sdkVersionSuffixPattern)
-  if (match === null || match.length < 2) {
+  if (swagger.info[sdkPatchLevelAttr] === undefined)  {
+    return 0
+  }
+  const level = Number(swagger.info[sdkPatchLevelAttr])
+  if (isNaN(level)) {
     return 0
   }
 
-  return Number(match[1])
+  return level
 }
 
 export function setPatchLevel(swagger: Record<string, any>, patchLevel: number) {
   if (swagger.info === undefined) {
     swagger.info = {}
   }
-
-  if (swagger.info.version === undefined) {
-    swagger.info.version = ''
-  }
-
-  swagger.info.version = swagger.info.version.replace(sdkVersionSuffixPattern, '') + `-SDK.${patchLevel}`
+  swagger.info[sdkPatchLevelAttr] = patchLevel
 }
 
 /**

--- a/test/services/codex.test.ts
+++ b/test/services/codex.test.ts
@@ -3,6 +3,7 @@ import { Codex } from '../../src/services/codex'
 import { idleState } from '../../src/services/state'
 import config from '../../src/services/config'
 import renderers from '../../src/renderers'
+import * as swagger from '../../src/services/swagger'
 
 import mocks from '../mocks'
 
@@ -16,7 +17,7 @@ describe('codex tests', async () => {
   const storageMock = new mocks.Storage({})
 
   const mockBaseline = {info: {version: 'v5.0'}}
-  const mockBaselineSDK1 = {info: {version: 'v5.0-SDK.1'}}
+  const mockBaselineSDK1 = {info: {version: 'v5.0', [swagger.sdkPatchLevelAttr]: 1}}
 
   const mockCodex = async (baseline: Record<string, any>, patches = {}) => {
 
@@ -57,7 +58,7 @@ describe('codex tests', async () => {
 
   it('should create the version data correctly', async () => {
 
-    const content = {info: {version: 'v5.0-SDK.1'}}
+    const content = {info: {version: 'v5.0', [swagger.sdkPatchLevelAttr]: 1 }}
 
     const codex = await mockCodex(mockBaseline)
     mockVdc(content)
@@ -112,7 +113,7 @@ describe('codex tests', async () => {
 
   it('should read the patch level', async () => {
     const level = 3
-    const baseline = {info: {version: `v5.0-SDK.${level}`}}
+    const baseline = {info: {version: 'v5.0', [swagger.sdkPatchLevelAttr]: level}}
 
     const codex = await mockCodex(baseline)
     expect(codex.getVersionPatchLevel()).to.deep.equal(level)
@@ -154,7 +155,7 @@ describe('codex tests', async () => {
   })
 
   it('should determine vdc updates', async () => {
-    const upstream = {info: {version: 'v5.0-SDK.2'}}
+    const upstream = {info: {version: 'v5.0', [swagger.sdkPatchLevelAttr]: 2 }}
     const codex = await mockCodex(mockBaselineSDK1, {
       '1.patch': 'foo',
       '1.txt': 'foo desc',
@@ -174,7 +175,7 @@ describe('codex tests', async () => {
 
   it('should throw when upstream has a greater patch level than the number of patches',  async () => {
     const codex = await mockCodex(mockBaseline)
-    const upstream = {info: {version: 'v5.0-SDK.2'}}
+    const upstream = {info: {version: 'v5.0', [swagger.sdkPatchLevelAttr]: 2 }}
     mockVdc(upstream)
 
     chai.use(chaiAsPromised)
@@ -207,7 +208,8 @@ describe('codex tests', async () => {
       swagger: '2.0',
       info: {
         description: 'Some description',
-        version: '5.0-SDK.1',
+        version: '5.0',
+        [swagger.sdkPatchLevelAttr]: 1,
         title: 'CLOUD API changed'
       }
     }
@@ -219,14 +221,13 @@ describe('codex tests', async () => {
 ===================================================================
 --- swagger.json
 +++ swagger.json
-@@ -1,8 +1,8 @@
- {
+@@ -2,7 +2,8 @@
    "swagger": "2.0",
    "info": {
      "description": "Some description",
--    "version": "5.0",
+     "version": "5.0",
 -    "title": "CLOUD API"
-+    "version": "5.0-SDK.1",
++    "${swagger.sdkPatchLevelAttr}": 1,
 +    "title": "CLOUD API changed"
    }
  }

--- a/test/services/swagger.test.ts
+++ b/test/services/swagger.test.ts
@@ -7,12 +7,12 @@ import renderers from '../../src/renderers'
 describe('swagger tests', function () {
   it('should get the patch level', () => {
     const level = 4
-    const content = {info: {version: `v5.0-SDK.${level}`}}
+    const content = {info: {version: '5.0', [swagger.sdkPatchLevelAttr]: level}}
     expect(swagger.getVersionPatchLevel(content)).to.equal(level)
   })
 
   it('should get a 0 patch level when there\'s none', () => {
-    const content = {info: {version: 'v5.0'}}
+    const content = {info: {version: '5.0'}}
     expect(swagger.getVersionPatchLevel(content)).to.equal(0)
   })
 
@@ -22,28 +22,29 @@ describe('swagger tests', function () {
   })
 
   it('should return 0 when there\'s an invalid patch level', () => {
-    const content = {info: {version: 'v5.0-SDK.foo'}}
+    const content = {info: {version: '5.0', [swagger.sdkPatchLevelAttr]: 'foo'}}
     expect(swagger.getVersionPatchLevel(content)).to.equal(0)
   })
 
   it('should correctly set the patch level', () => {
-    const json = {
+    const json: Record<string, any> = {
       info: {
         version: '5.0'
       }
     }
     swagger.setPatchLevel(json, 3)
-    expect(json.info.version).to.be.equal('5.0-SDK.3')
+    expect(json.info[swagger.sdkPatchLevelAttr]).to.be.equal(3)
   })
 
   it('should correctly change the patch level', () => {
-    const json = {
+    const json: Record<string, any> = {
       info: {
-        version: '5.0-SDK.1'
+        version: '5.0',
+        [swagger.sdkPatchLevelAttr]: 1
       }
     }
     swagger.setPatchLevel(json, 2)
-    expect(json.info.version).to.be.equal('5.0-SDK.2')
+    expect(json.info[swagger.sdkPatchLevelAttr]).to.be.equal(2)
   })
 
   it('should correctly fix the patch level in a file', () => {
@@ -64,14 +65,14 @@ describe('swagger tests', function () {
 
     let result = JSON.parse(fs.readFileSync(fileName).toString())
 
-    expect(result.info.version).to.be.equal(`5.0-SDK.${patchLevel1}`)
+    expect(result.info[swagger.sdkPatchLevelAttr]).to.be.equal(patchLevel1)
     expect(swagger.getVersionPatchLevel(result)).to.equal(patchLevel1)
 
     swagger.fixPatchLevel(fileName, patchLevel2, renderers.json)
 
     result = JSON.parse(fs.readFileSync(fileName).toString())
 
-    expect(result.info.version).to.be.equal(`5.0-SDK.${patchLevel2}`)
+    expect(result.info[swagger.sdkPatchLevelAttr]).to.be.equal(patchLevel2)
     expect(swagger.getVersionPatchLevel(result)).to.equal(patchLevel2)
 
     /* not is should leave it as it is */
@@ -79,7 +80,7 @@ describe('swagger tests', function () {
 
     result = JSON.parse(fs.readFileSync(fileName).toString())
 
-    expect(result.info.version).to.be.equal(`5.0-SDK.${patchLevel2}`)
+    expect(result.info[swagger.sdkPatchLevelAttr]).to.be.equal(patchLevel2)
     expect(swagger.getVersionPatchLevel(result)).to.equal(patchLevel2)
 
     mock.restore()
@@ -88,7 +89,7 @@ describe('swagger tests', function () {
   it('should fill in missing info', () => {
     const dummy: Record<string, any> = {}
     swagger.setPatchLevel(dummy, 3)
-    expect(dummy.info).to.have.property('version')
-    expect(dummy.info.version).to.be.equal('-SDK.3')
+    expect(dummy.info).to.have.property(swagger.sdkPatchLevelAttr)
+    expect(dummy.info[swagger.sdkPatchLevelAttr]).to.be.equal(3)
   })
 })


### PR DESCRIPTION
using x-sdk-patch-level to store the patch level instead of the version suffix