### PR TITLE
fix: apply patch even if it is already deployed in upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,7 @@
 
 - apply only the last patch that it is not present in the upstream
 - get patch level from API version OR vendor extension
+
+## v5.0.1
+
+- bug-fix: apply the last patch even if it is deployed in production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,4 @@
 
 ## v5.0.1
 
-- bug-fix: apply the last patch even if it is deployed in production
+- bug-fix: apply the last patch even if it is deployed in upstream and the baseline is not updated yet

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ OPTIONS
   -m, --message=message
 ```
 
-_See code: [src/commands/commit.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/commit.ts)_
+_See code: [src/commands/commit.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/commit.ts)_
 
 ## `codex compile`
 
@@ -97,7 +97,7 @@ OPTIONS
   -o, --output=output
 ```
 
-_See code: [src/commands/compile.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/compile.ts)_
+_See code: [src/commands/compile.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/compile.ts)_
 
 ## `codex config [PATH] [VALUE]`
 
@@ -121,7 +121,7 @@ EXAMPLES
   $ codex config foo.bar value
 ```
 
-_See code: [src/commands/config.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/config.ts)_
+_See code: [src/commands/config.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/config.ts)_
 
 ## `codex diff FILE1 FILE2`
 
@@ -144,7 +144,7 @@ OPTIONS
   -s, --semantic          perform a swagger semantic diff
 ```
 
-_See code: [src/commands/diff.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/diff.ts)_
+_See code: [src/commands/diff.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/diff.ts)_
 
 ## `codex edit`
 
@@ -162,7 +162,7 @@ OPTIONS
   -p, --patch=patch
 ```
 
-_See code: [src/commands/edit.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/edit.ts)_
+_See code: [src/commands/edit.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/edit.ts)_
 
 ## `codex help [COMMAND]`
 
@@ -203,7 +203,7 @@ EXAMPLE
 
 ❗ _Note_: make sure the new bucket supports versioning in order to save older versions of the swagger files over time.
 
-_See code: [src/commands/init.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/init.ts)_
 
 ## `codex lock`
 
@@ -221,7 +221,7 @@ EXAMPLE
   $ codex lock
 ```
 
-_See code: [src/commands/lock.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/lock.ts)_
+_See code: [src/commands/lock.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/lock.ts)_
 
 ## `codex login`
 
@@ -241,7 +241,7 @@ EXAMPLE
   $ codex login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/login.ts)_
 
 ## `codex normalize FILE`
 
@@ -260,7 +260,7 @@ OPTIONS
   -i, --indent=indent     [default: 2]
 ```
 
-_See code: [src/commands/normalize.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/normalize.ts)_
+_See code: [src/commands/normalize.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/normalize.ts)_
 
 ## `codex patch`
 
@@ -281,7 +281,7 @@ OPTIONS
   -r, --rm=rm            remove the specified patch
 ```
 
-_See code: [src/commands/patch.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/patch.ts)_
+_See code: [src/commands/patch.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/patch.ts)_
 
 ## `codex sdk-changes`
 
@@ -299,7 +299,7 @@ EXAMPLE
   $ codex sdk-changes
 ```
 
-_See code: [src/commands/sdk-changes.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/sdk-changes.ts)_
+_See code: [src/commands/sdk-changes.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/sdk-changes.ts)_
 
 ## `codex state`
 
@@ -315,7 +315,7 @@ OPTIONS
   --reset
 ```
 
-_See code: [src/commands/state.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/state.ts)_
+_See code: [src/commands/state.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/state.ts)_
 
 ## `codex status`
 
@@ -334,7 +334,7 @@ EXAMPLE
   $ codex status
 ```
 
-_See code: [src/commands/status.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/status.ts)_
+_See code: [src/commands/status.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/status.ts)_
 
 ## `codex unlock`
 
@@ -352,7 +352,7 @@ EXAMPLE
   $ codex unlock
 ```
 
-_See code: [src/commands/unlock.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/unlock.ts)_
+_See code: [src/commands/unlock.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/unlock.ts)_
 
 ## `codex update`
 
@@ -370,5 +370,5 @@ OPTIONS
   -y, --yes            answer yes to all questions; useful in CI automation
 ```
 
-_See code: [src/commands/update.ts](https://github.com/ionos-cloud/codex/blob/v5.0.0/src/commands/update.ts)_
+_See code: [src/commands/update.ts](https://github.com/ionos-cloud/codex/blob/v5.0.1/src/commands/update.ts)_
 <!-- commandsstop -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ionos-cloud/codex",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ionos-cloud/codex",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/command": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ionos-cloud/codex",
   "description": "VDC & SDK swagger management tool",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "Florin Mihalache",
   "bin": {
     "codex": "bin/run"

--- a/src/services/codex.ts
+++ b/src/services/codex.ts
@@ -4,13 +4,13 @@ import * as swagger from './swagger'
 import * as diff from 'diff'
 import ui from './ui'
 import state from './state'
-import { PatchError } from '../exceptions/patch-error'
+import {PatchError} from '../exceptions/patch-error'
 import chalk from 'chalk'
-import { ApiConfig, CodexFormat, CodexStorage, PatchesCollection } from '../contract/codex-storage'
-import { S3 } from '../storage/s3'
+import {ApiConfig, CodexFormat, CodexStorage, PatchesCollection} from '../contract/codex-storage'
+import {S3} from '../storage/s3'
 import axios from 'axios'
-import { CodexRenderer } from '../contract/codex-renderer'
-import renderers, { DEFAULT_RENDERER } from '../renderers'
+import {CodexRenderer} from '../contract/codex-renderer'
+import renderers, {DEFAULT_RENDERER} from '../renderers'
 
 export interface UpstreamUpdateInfo {
   content: string;
@@ -145,8 +145,11 @@ export class Codex {
     const upstream = await this.fetchSwaggerFile()
     const upstreamPatchLevel = swagger.getVersionPatchLevel(upstream)
 
-    // apply only last patch
-    if (level > upstreamPatchLevel) {
+    // apply only last patch even if it is deployed in production
+    if (level >= upstreamPatchLevel) {
+      if (level === upstreamPatchLevel) {
+        ui.debug(`note: patch ${level} is already deployed in upstream`)
+      }
       const patchedContent = await this.applyPatch(content, level)
       ui.debug(`applying patch ${level}`)
       if (patchedContent === false) {


### PR DESCRIPTION
Apply patch even if it is already deployed in upstream but the baseline is not updated with the latest changes.