### PR TITLE
fix: check baseline level before applying patch

### DIFF
--- a/src/services/codex.ts
+++ b/src/services/codex.ts
@@ -145,10 +145,10 @@ export class Codex {
     const upstream = await this.fetchSwaggerFile()
     const upstreamPatchLevel = swagger.getVersionPatchLevel(upstream)
 
-    // apply only last patch even if it is deployed in production
-    if (level >= upstreamPatchLevel) {
+    // apply only last patch even if it is deployed in production and baseline is not yet updated
+    if (level >= upstreamPatchLevel && this.versionPatchLevel < upstreamPatchLevel) {
       if (level === upstreamPatchLevel) {
-        ui.debug(`note: patch ${level} is already deployed in upstream`)
+        ui.debug(`patch ${level} is deployed in upstream (upstream patch level: ${upstreamPatchLevel}), baseline is not updated (baseline patch level: ${this.versionPatchLevel})`)
       }
       const patchedContent = await this.applyPatch(content, level)
       ui.debug(`applying patch ${level}`)


### PR DESCRIPTION
Right now, a patch will be applied even if it is deployed in upstream. But if the baseline is updated with upstream and it contains the patch, there's no need for the patch to be reapplied.

Added a check for the baseline and upstream patch level. 