### PR TITLE
fix: apply patch after checking baseline and upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,7 @@
 ## v5.0.3
 
 - bug-fix: apply the last patch, revert latest changes
+
+## v5.0.4
+
+- bug-fix: apply the last patch, when the patch level is higher than upstream level and when they are equal, if the baseline was not updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ionos-cloud/codex",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ionos-cloud/codex",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "MIT",
       "dependencies": {
         "@oclif/command": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ionos-cloud/codex",
   "description": "VDC & SDK swagger management tool",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "author": "Florin Mihalache",
   "bin": {
     "codex": "bin/run"

--- a/src/services/codex.ts
+++ b/src/services/codex.ts
@@ -149,10 +149,9 @@ export class Codex {
     if (level > upstreamPatchLevel) {
       content = await this.applyLastPatch(content, level);
     } else if (level === upstreamPatchLevel && this.versionPatchLevel < upstreamPatchLevel) {
-      // apply only last patch if it is deployed in production and baseline is not yet updated
       ui.debug(`upstream patch level: ${upstreamPatchLevel}, baseline patch level: ${this.versionPatchLevel}`)
       ui.debug(`patch ${level} is deployed in upstream, baseline is not updated`)
-
+      // apply only last patch if it is deployed in production and baseline is not yet updated
       content = await this.applyLastPatch(content, level);
     } else {
       ui.debug('there is no patch to apply')

--- a/src/services/codex.ts
+++ b/src/services/codex.ts
@@ -145,6 +145,7 @@ export class Codex {
     const upstream = await this.fetchSwaggerFile()
     const upstreamPatchLevel = swagger.getVersionPatchLevel(upstream)
 
+    // apply only last patch
     if (level > upstreamPatchLevel) {
       const patchedContent = await this.applyPatch(content, level)
       ui.debug(`applying patch ${level}`)
@@ -155,7 +156,7 @@ export class Codex {
       }
       content = patchedContent as string
     } else if (level === upstreamPatchLevel && this.versionPatchLevel < upstreamPatchLevel) {
-      // apply only last patch even if it is deployed in production and baseline is not yet updated
+      // apply only last patch if it is deployed in production and baseline is not yet updated
       ui.debug(`upstream patch level: ${upstreamPatchLevel}, baseline patch level: ${this.versionPatchLevel}`)
       ui.debug(`patch ${level} is deployed in upstream, baseline is not updated`)
 

--- a/src/services/codex.ts
+++ b/src/services/codex.ts
@@ -147,32 +147,29 @@ export class Codex {
 
     // apply only last patch
     if (level > upstreamPatchLevel) {
-      const patchedContent = await this.applyPatch(content, level)
-      ui.debug(`applying patch ${level}`)
-      if (patchedContent === false) {
-        ui.error(`failed to apply patch ${level}`)
-        /* patch failed, mark the state and throw */
-        throw new PatchError('failed to apply patch', level, content)
-      }
-      content = patchedContent as string
+      content = await this.applyLastPatch(content, level);
     } else if (level === upstreamPatchLevel && this.versionPatchLevel < upstreamPatchLevel) {
       // apply only last patch if it is deployed in production and baseline is not yet updated
       ui.debug(`upstream patch level: ${upstreamPatchLevel}, baseline patch level: ${this.versionPatchLevel}`)
       ui.debug(`patch ${level} is deployed in upstream, baseline is not updated`)
 
-      const patchedContent = await this.applyPatch(content, level)
-      ui.debug(`applying patch ${level}`)
-      if (patchedContent === false) {
-        ui.error(`failed to apply patch ${level}`)
-        /* patch failed, mark the state and throw */
-        throw new PatchError('failed to apply patch', level, content)
-      }
-      content = patchedContent as string
+      content = await this.applyLastPatch(content, level);
     } else {
       ui.debug('there is no patch to apply')
     }
 
     return content
+  }
+
+  private async applyLastPatch(content: string, level: number) {
+    const patchedContent = await this.applyPatch(content, level)
+    ui.debug(`applying patch ${level}`)
+    if (patchedContent === false) {
+      ui.error(`failed to apply patch ${level}`)
+      /* patch failed, mark the state and throw */
+      throw new PatchError('failed to apply patch', level, content)
+    }
+    return patchedContent as string
   }
 
   async compileAll(): Promise<string> {

--- a/test/services/codex.test.ts
+++ b/test/services/codex.test.ts
@@ -189,7 +189,7 @@ describe('codex tests', async () => {
     nock.cleanAll()
   })
 
-  it('should apply patch when upstream has the patch already deployed', async () => {
+  it('should apply patch when upstream has the patch already deployed and baseline not yet updated', async () => {
     // having 2 patches in codex, baseline has only 1
     // 2 patches are deployed in upstream, but the baseline from codex was not updated
     const codex = await mockCodex(mockBaselineSDK1, {


### PR DESCRIPTION
## What does this fix or implement?

When applying patch, we need to consider 3 numbers: the patch level, the baseline level, and the upstream level.
if `patch level > upstream level` **apply** patch.
if `patch level == upstream level`, will check if `baseline level < upstream level` - **apply** patch (it means the patch was deployed in upstream, but the baseline was not updated yet in codex.
in all other situations do **not** apply patch.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. `feat:`/`fix:`/`doc:`/`test:`/`refactor:`)
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] `package.json`, `package-lock.json`, `CHANGELOG.md` updated if a new release is coming
