### PR TITLE
enhancement: make -m required for commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,35 @@
-## v4.0.0
-( yes, we start the changelog with v4.0.0 :) )
+## v5.0.5
 
-- yaml support for input specs
-- bash and zsh autocompletion
+- enhancement: make `-m` flag for `codex commit` required
 
-## v4.1.0
+## v5.0.4
 
-- use `x-sdk-patch-level` to store the patch level instead of the version suffix 
+- bug-fix: apply the last patch, when the patch level is higher than upstream level and when they are equal, if the baseline was not updated
 
-## v5.0.0
+## v5.0.3
 
-- apply only the last patch that it is not present in the upstream
-- get patch level from API version OR vendor extension
+- bug-fix: apply the last patch, revert latest changes
+
+## v5.0.2
+
+- bug-fix: apply the last patch even if it is deployed in upstream and the baseline is not updated yet
 
 ## v5.0.1
 
 - bug-fix: apply the last patch even if it is deployed in upstream
 - bug-fix: perform diff even if semantic option is not set
 
-## v5.0.2
+## v5.0.0
 
-- bug-fix: apply the last patch even if it is deployed in upstream and the baseline is not updated yet
+- apply only the last patch that it is not present in the upstream
+- get patch level from API version OR vendor extension
 
-## v5.0.3
+## v4.1.0
 
-- bug-fix: apply the last patch, revert latest changes
+- use `x-sdk-patch-level` to store the patch level instead of the version suffix
 
-## v5.0.4
+## v4.0.0
+( yes, we start the changelog with v4.0.0 :) )
 
-- bug-fix: apply the last patch, when the patch level is higher than upstream level and when they are equal, if the baseline was not updated
+- yaml support for input specs
+- bash and zsh autocompletion

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ionos-cloud/codex",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ionos-cloud/codex",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "MIT",
       "dependencies": {
         "@oclif/command": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ionos-cloud/codex",
   "description": "VDC & SDK swagger management tool",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "author": "Florin Mihalache",
   "bin": {
     "codex": "bin/run"

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -14,7 +14,7 @@ export default class Commit extends BaseCommand {
 
   static flags = {
     ...BaseCommand.flags,
-    message: flags.string({char: 'm', required: false})
+    message: flags.string({char: 'm', required: true})
   }
 
   async run() {


### PR DESCRIPTION
I think codex very closely emulates `git` - so it makes sense to make this parameter required. I instinctively press enter `codex commit` as prompted by `codex edit` expecting an error message stating required params - but it straight up pushes my changes to baseline - which is unexpected