### PR TITLE
fix: pin axios to v1.14.0 — supply chain attack mitigation [CRITICAL]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@oclif/core": "^3",
         "@oclif/plugin-autocomplete": "^3",
         "@oclif/plugin-help": "^6",
-        "axios": "^1.7",
+        "axios": "1.14.0",
         "chalk": "^4",
         "diff": "^8.0.3",
         "enquirer": "^2.3.6",
@@ -4696,13 +4696,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -9448,9 +9449,13 @@
       "dev": true
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -14848,13 +14853,13 @@
       }
     },
     "axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "requires": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "balanced-match": {
@@ -18303,9 +18308,9 @@
       "dev": true
     },
     "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
     "punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@oclif/plugin-autocomplete": "^3",
     "@oclif/plugin-help": "^6",
     "@aws-sdk/client-s3": "^3",
-    "axios": "^1.7",
+    "axios": "1.14.0",
     "chalk": "^4",
     "diff": "^8.0.3",
     "enquirer": "^2.3.6",


### PR DESCRIPTION
## Summary
- **CRITICAL**: Pin axios dependency from `^1.7` to exact `1.14.0` to mitigate the supply chain attack discovered on March 30-31, 2026
- The previous caret range `^1.7` **directly includes the compromised `v1.14.1`**
- Compromised versions deploy a RAT via malicious `postinstall` hook (C2 at `sfrclak[.]com:8000`)
- Any `npm install` that ran between March 30-31 with this range may have pulled the malicious version

## Immediate actions required
- [ ] **Check CI/CD logs** for any `npm install` runs between March 30-31, 2026
- [ ] **Check network logs** for connections to `sfrclak[.]com:8000`
- [ ] **Check for IOCs**: macOS `/Library/Caches/com.apple.act.mond`, Linux `/tmp/ld.py`, Windows `%PROGRAMDATA%\wt.exe`

## Test plan
- [ ] Verify `npm install` completes without errors
- [ ] Run existing test suite to confirm no breaking changes
- [ ] Verify lockfile contains exactly `axios@1.14.0`

## References
- [Socket Research: Axios npm package compromised](https://socket.dev/blog/axios-npm-package-compromised)
- [ISMS Advisory](https://confluence.united-internet.org/pages/viewpage.action?pageId=689217453)