### PR TITLE
feat: add set-url command to update specUrl in api-config.json

### DIFF
--- a/src/commands/set-url.ts
+++ b/src/commands/set-url.ts
@@ -1,0 +1,32 @@
+import { Args } from '@oclif/core'
+import { S3 } from '../storage/s3'
+import BaseCommand from '../base/base-command'
+import ui from '../services/ui'
+
+export default class SetUrl extends BaseCommand {
+  static description = 'update the API spec URL in api-config.json'
+
+  static examples = [
+    '$ codex set-url https://api.example.com/swagger.json',
+  ]
+
+  static flags = { ...BaseCommand.flags }
+
+  static args = {
+    url: Args.string({
+      required: true,
+      description: 'new API spec URL',
+    })
+  }
+
+  async run() {
+    const storage = new S3()
+    const apiConfig = await storage.getApiConfig()
+    const oldUrl = apiConfig.specUrl
+
+    apiConfig.specUrl = this.args.url
+    await storage.writeApiConfig(apiConfig)
+
+    ui.info(`spec URL updated: ${oldUrl} → ${this.args.url}`)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new `codex set-url <url>` command that updates the `specUrl` field in `api-config.json` stored in S3
- Eliminates the need to manually download, edit, and re-upload the file when the upstream API spec URL changes
- Preserves the existing `format` field untouched

## Test plan
- [ ] Run `npm install && npm run build` to verify it compiles
- [ ] Configure S3 credentials with `codex config`
- [ ] Run `./bin/run set-url https://new-url.com/spec.json` and verify the terminal shows old → new URL
- [ ] Confirm the change was persisted by re-initialising or reading `api-config.json` from S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)